### PR TITLE
Restrict docker version in requirements.in.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ flake8
 pytest
 pytest-cov
 sphinx
+docker<4.3.0

--- a/requirements/3.5.txt
+++ b/requirements/3.5.txt
@@ -24,7 +24,7 @@ cx-oracle==8.0.0          # via testcontainers
 deprecation==2.1.0        # via testcontainers
 distro==1.5.0             # via docker-compose
 docker-compose==1.26.2    # via testcontainers
-docker[ssh]==4.2.0        # via docker-compose, testcontainers
+docker[ssh]==4.2.2        # via -r requirements.in, docker-compose, testcontainers
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.16            # via sphinx

--- a/requirements/3.6.txt
+++ b/requirements/3.6.txt
@@ -24,7 +24,7 @@ cx-oracle==8.0.0          # via testcontainers
 deprecation==2.1.0        # via testcontainers
 distro==1.5.0             # via docker-compose
 docker-compose==1.26.2    # via testcontainers
-docker[ssh]==4.2.0        # via docker-compose, testcontainers
+docker[ssh]==4.2.2        # via -r requirements.in, docker-compose, testcontainers
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.16            # via sphinx

--- a/requirements/3.7.txt
+++ b/requirements/3.7.txt
@@ -24,7 +24,7 @@ cx-oracle==8.0.0          # via testcontainers
 deprecation==2.1.0        # via testcontainers
 distro==1.5.0             # via docker-compose
 docker-compose==1.26.2    # via testcontainers
-docker[ssh]==4.2.0        # via docker-compose, testcontainers
+docker[ssh]==4.2.2        # via -r requirements.in, docker-compose, testcontainers
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.16            # via sphinx

--- a/requirements/3.8.txt
+++ b/requirements/3.8.txt
@@ -24,7 +24,7 @@ cx-oracle==8.0.0          # via testcontainers
 deprecation==2.1.0        # via testcontainers
 distro==1.5.0             # via docker-compose
 docker-compose==1.26.2    # via testcontainers
-docker[ssh]==4.2.0        # via docker-compose, testcontainers
+docker[ssh]==4.2.2        # via -r requirements.in, docker-compose, testcontainers
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.16            # via sphinx


### PR DESCRIPTION
@eastlondoner, this should ensure that updating dependencies in the future does not interfere with the restricted docker version.